### PR TITLE
Windows Port + CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(narc LANGUAGES C)
+set(CMAKE_C_STANDARD 99)
+
+if (WIN32)
+    include(FetchContent)
+    FetchContent_Declare(
+        dirent
+        URL https://github.com/tronkko/dirent/archive/refs/tags/1.26.zip
+        DOWNLOAD_EXTRACT_TIMESTAMP ON
+    )
+    FetchContent_MakeAvailable(dirent)
+
+    add_compile_options(/wd4267 /wd4244)
+endif()
+
+add_subdirectory(lib)
+add_subdirectory(cli)

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.15)
+
+# Read version from .version file
+file(READ "${CMAKE_SOURCE_DIR}/.version" NARC_VERSION)
+string(STRIP "${NARC_VERSION}" NARC_VERSION)
+
+# Generate version.h header
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/version.h.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/include/version.h"
+    @ONLY
+)
+
+set(CLI_SOURCES
+    "src/narc.c"
+    "src/narc_create.c"
+    "src/narc_extract.c"
+    "src/narc_help.c"
+    "src/narc_info.c"
+    "src/narc_yank.c"
+    "src/strbuild.c"
+    "src/strutil.c"
+    "src/strvec.c")
+
+# Add Windows-specific fnmatch implementation
+if (WIN32)
+    list(APPEND CLI_SOURCES "src/fnmatch_win.c")
+endif()
+
+add_executable(narc ${CLI_SOURCES})
+target_include_directories(narc PRIVATE
+    include
+    ${CMAKE_CURRENT_BINARY_DIR}/include
+)
+target_link_libraries(narc PRIVATE libnarc_static)
+
+# Link Windows Shell API for PathMatchSpecA
+if (WIN32)
+    target_link_libraries(narc PRIVATE shlwapi)
+    target_link_libraries(narc PRIVATE dirent)
+    target_compile_definitions(narc PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 
-# Read version from .version file
-file(READ "${CMAKE_SOURCE_DIR}/.version" NARC_VERSION)
+# Read version from .version file in project root
+file(READ "${CMAKE_CURRENT_LIST_DIR}/../.version" NARC_VERSION)
 string(STRIP "${NARC_VERSION}" NARC_VERSION)
 
 # Generate version.h header

--- a/cli/include/fnmatch_win.h
+++ b/cli/include/fnmatch_win.h
@@ -1,0 +1,25 @@
+/*
+ * Windows-compatible fnmatch implementation blah blah
+ */
+
+#ifndef FNMATCH_WIN_H
+#define FNMATCH_WIN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define FNM_NOMATCH     1
+#define FNM_NOESCAPE    0x01
+#define FNM_PATHNAME    0x02
+#define FNM_PERIOD      0x04
+#define FNM_LEADING_DIR 0x08
+#define FNM_CASEFOLD    0x10
+
+int fnmatch(const char *pattern, const char *string, int flags);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FNMATCH_WIN_H */

--- a/cli/src/fnmatch_win.c
+++ b/cli/src/fnmatch_win.c
@@ -1,0 +1,12 @@
+/*
+ * Windows-compatible fnmatch implementation using PathMatchSpecA
+ */
+
+#include "fnmatch_win.h"
+#include <shlwapi.h>
+
+int fnmatch(const char *pattern, const char *string, int flags)
+{
+    // PathMatchSpecA returns TRUE on match, fnmatch returns 0 on match
+    return PathMatchSpecA(string, pattern) ? 0 : FNM_NOMATCH;
+}

--- a/cli/src/narc_create.c
+++ b/cli/src/narc_create.c
@@ -17,12 +17,22 @@
 #include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
+#if defined(WIN32) || defined(_MSC_VER)
+#include "fnmatch_win.h"
+#else
 #include <fnmatch.h>
+#endif
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined(WIN32) || defined(_MSC_VER)
+#include <direct.h>
+#define getcwd _getcwd
+#define chdir _chdir
+#else
 #include <unistd.h>
+#endif
 
 #include <sys/stat.h>
 
@@ -150,7 +160,7 @@ static int parse_opts(int *argc, const char ***argv, struct options *opts)
         }
     }
 
-    return orig_argv - *argv;
+    return (int)(orig_argv - *argv);
 }
 
 static int pack(struct options *opts)

--- a/cli/src/narc_info.c
+++ b/cli/src/narc_info.c
@@ -17,6 +17,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 #include <narc/api/error.h>
 #include <narc/api/files.h>
@@ -86,7 +87,7 @@ int info(int argc, const char **argv)
 
     for (size_t i = 0; i < fatb_meta->num_files; i++, fatb++) {
         char *ext = narc_files_getext(fimg + fatb->start);
-        printf("  - %05ld -> { start = 0x%08X, size = 0x%08X, filetype = %-8s }\n", i, fatb->start, fatb->end - fatb->start, ext);
+        printf("  - %05" PRIu64 " -> { start = 0x%08X, size = 0x%08X, filetype = %-8s }\n", i, fatb->start, fatb->end - fatb->start, ext);
         free(ext);
     }
 

--- a/cli/src/strutil.c
+++ b/cli/src/strutil.c
@@ -24,7 +24,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(WIN32) || defined(_MSC_VER)
 #include <sys/stat.h>
+#ifndef S_ISDIR
+#define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+#endif
+#else
+#include <sys/stat.h>
+#endif
 
 char *basename(const char *path)
 {
@@ -82,7 +89,7 @@ char *strcpy_fext(const char *path, const char *ext)
         p = (char *)path;
     }
 
-    int len = p - path;
+    int len = (int)(p - path);
     char *buf = malloc(len + strlen(ext) + 2);
     sprintf(buf, "%.*s.%s", len, path, ext);
     return buf;

--- a/cli/version.h.in
+++ b/cli/version.h.in
@@ -1,0 +1,8 @@
+/* THIS HEADER IS AUTOMATICALLY GENERATED */
+/*          DO NOT MODIFY IT!!!           */
+#ifndef NARC_VERSION_H
+#define NARC_VERSION_H
+
+#define NARC_VERSION "@NARC_VERSION@"
+
+#endif /* NARC_VERSION_H */

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.15)
+
+set(LIB_SOURCES
+    # check API
+    "src/check/narc_check.c"
+    "src/check/narc_check_fatb.c"
+    "src/check/narc_check_fimg.c"
+    "src/check/narc_check_fntb.c"
+    "src/check/narc_check_header.c"
+    "src/check/narc_check_header_fsize.c"
+    "src/check/narc_check_vfs.c"
+
+    # dump API
+    "src/dump/narc_dump.c"
+
+    # error API
+    "src/error/narc_strerror.c"
+
+    # files API
+    "src/files/narc_files_getext.c"
+    "src/files/narc_files_getimg.c"
+
+    # load API
+    "src/load/narc_load.c"
+
+    # pack API
+    "src/pack/narc_pack.c"
+    "src/pack/narc_pack_file.c"
+    "src/pack/narc_pack_file_copy.c"
+    "src/pack/narc_pack_halt.c"
+    "src/pack/narc_pack_start.c")
+
+add_library(libnarc SHARED ${LIB_SOURCES})
+add_library(libnarc_static STATIC ${LIB_SOURCES})
+target_include_directories(libnarc PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(libnarc_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+if (WIN32)
+    target_compile_definitions(libnarc PRIVATE _CRT_SECURE_NO_WARNINGS)
+    target_compile_definitions(libnarc_static PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()


### PR DESCRIPTION
Ports both the cli and lib components to windows, making use of `#if` blocks that check for either `WIN32` or `_MSC_VER` defines.
Additionally, I added support for building with CMake.

I added the files `fnmatch_win.h/c`, maybe a bit overkill so lmk if you want me to just inline the ifdef.

I tested the CLI on both Windows 10 and 11, as well as Ubuntu 24.04, all of which seem to be working fine.